### PR TITLE
Add SuperHTML language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SuperHTML support for Zed
 
-This extension provides support for [SuperHTML](https://github.com/kristoff-it/superhtml) language server.
+This extension provides support for the [SuperHTML](https://github.com/kristoff-it/superhtml) language and LSP.
 
 ## Installation
 

--- a/extension.toml
+++ b/extension.toml
@@ -8,4 +8,9 @@ repository = "https://github.com/WeetHet/superhtml-zed"
 
 [language_servers.superhtml]
 name = "superhtml"
-languages = ["HTML"]
+languages = ["HTML", "SuperHTML"]
+
+[grammars.superhtml]
+repository = "https://github.com/kristoff-it/superhtml"
+commit = "48c3d2285d6c95bbcfb4055c8c84a2c1079fb2aa"
+path = "tree-sitter-superhtml"

--- a/languages/superhtml/brackets.scm
+++ b/languages/superhtml/brackets.scm
@@ -1,0 +1,5 @@
+("<" @open "/>" @close)
+("</" @open ">" @close)
+("<" @open ">" @close)
+("\"" @open "\"" @close)
+((element (start_tag) @open (end_tag) @close) (#set! newline.only))

--- a/languages/superhtml/config.toml
+++ b/languages/superhtml/config.toml
@@ -1,0 +1,16 @@
+name = "SuperHTML"
+grammar = "superhtml"
+path_suffixes = ["shtml"]
+autoclose_before = ">})"
+block_comment = { start = "<!--", prefix = "", end = "-->", tab_size = 0 }
+wrap_characters = { start_prefix = "<", start_suffix = ">", end_prefix = "</", end_suffix = ">" }
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },
+    { start = "<", end = ">", close = false, newline = true, not_in = ["comment", "string"] },
+    { start = "!--", end = " --", close = true, newline = false, not_in = ["comment", "string"] },
+]
+completion_query_characters = ["-"]
+prettier_parser_name = "html"

--- a/languages/superhtml/highlights.scm
+++ b/languages/superhtml/highlights.scm
@@ -1,0 +1,44 @@
+(doctype) @constant
+
+(comment) @comment
+
+(tag_name) @tag
+
+((tag_name) @string.special
+  (#any-of? @string.special "super" "extend"))
+
+(attribute_name) @attribute
+
+(attribute_value) @string
+
+((element
+  (start_tag
+    (attribute
+      (attribute_name) @attribute
+      [
+        (attribute_value) @link_uri
+        (quoted_attribute_value
+          (attribute_value) @link_uri)
+      ]))
+  (element
+    (start_tag
+      (tag_name) @tag)))
+  (#eq? @tag "super")
+  (#eq? @attribute "id"))
+
+(element
+  (start_tag
+    (tag_name) @string.special)
+  (#eq? @string.special "super"))
+
+"\"" @string
+
+[
+  "<"
+  ">"
+  "</"
+  "/>"
+  "<!"
+] @punctuation.bracket
+
+"=" @punctuation.delimiter

--- a/languages/superhtml/indents.scm
+++ b/languages/superhtml/indents.scm
@@ -1,0 +1,6 @@
+(start_tag ">" @end) @indent
+(self_closing_tag "/>" @end) @indent
+
+(element
+  (start_tag) @start
+  (end_tag)? @end) @indent

--- a/languages/superhtml/injections.scm
+++ b/languages/superhtml/injections.scm
@@ -1,0 +1,7 @@
+((script_element
+  (raw_text) @injection.content)
+ (#set! injection.language "javascript"))
+
+((style_element
+  (raw_text) @injection.content)
+ (#set! injection.language "css"))

--- a/languages/superhtml/outline.scm
+++ b/languages/superhtml/outline.scm
@@ -1,0 +1,5 @@
+(comment) @annotation
+
+(element
+  (start_tag
+    (tag_name) @name)) @item

--- a/languages/superhtml/textobjects.scm
+++ b/languages/superhtml/textobjects.scm
@@ -1,0 +1,1 @@
+(comment) @comment.around


### PR DESCRIPTION
this lets the lsp detect files as actually being superhtml since it gets it from the language id that the editor sends back. highlights are (slightly modified) from nvim-treesitter, the in-tree ones seem to be a little weird, im guessing they were meant for helix 